### PR TITLE
some publishDir changes

### DIFF
--- a/bin/consolidate_bins.py
+++ b/bin/consolidate_bins.py
@@ -233,6 +233,10 @@ def main(args):
         if not os.stat(os.path.join(dereplicated_bins, item)).st_size:
             os.remove(os.path.join(dereplicated_bins, item))
 
+    # write dereplicated_list.tsv
+    with open("dereplicated_list.tsv", 'w') as file_out:
+        drep_bins = os.listdir(dereplicated_bins)
+        file_out.write('\n'.join(drep_bins))
 
 if __name__ == '__main__':
     args = parse_args()

--- a/config/modules.config
+++ b/config/modules.config
@@ -67,47 +67,12 @@ process {
             [
                 path: "${params.outdir}/qc/prokaryotes/checkm2",
                 mode: params.publish_dir_mode,
-                pattern: "*.?sv"
-            ]
-        ]
-    }
-
-    withName: "CHECKM2_REFINE" {
-        publishDir = [
-            [
-                path: "${params.outdir}/intermediate_steps/prokaryotes/checkm2/refinement",
-                mode: params.publish_dir_mode,
-                pattern: "all_stats.csv"
-            ]
-        ]
-    }
-
-    withName: "CHECKM2_BINNER1" {
-        publishDir = [
+                pattern: "aggregated*.?sv"
+            ],
             [
                 path: "${params.outdir}/intermediate_steps/prokaryotes/refinement/checkm2",
                 mode: params.publish_dir_mode,
-                pattern: "binner1_filtered_genomes.tsv"
-            ]
-        ]
-    }
-
-    withName: "CHECKM2_BINNER2" {
-        publishDir = [
-            [
-                path: "${params.outdir}/intermediate_steps/prokaryotes/refinement/checkm2",
-                mode: params.publish_dir_mode,
-                pattern: "binner2_filtered_genomes.tsv"
-            ]
-        ]
-    }
-
-    withName: "CHECKM2_BINNER3" {
-        publishDir = [
-            [
-                path: "${params.outdir}/intermediate_steps/prokaryotes/refinement/checkm2",
-                mode: params.publish_dir_mode,
-                pattern: "binner3_filtered_genomes.tsv"
+                pattern: "binner*.?sv"
             ]
         ]
     }

--- a/config/modules.config
+++ b/config/modules.config
@@ -45,7 +45,7 @@ process {
     withName: BUSCO {
         publishDir = [
             [
-                path: "${params.outdir}/qc/busco/",
+                path: "${params.outdir}/qc/eukaryotes/busco/",
                 mode: params.publish_dir_mode,
                 failOnError: true,
             ]
@@ -55,19 +55,9 @@ process {
     withName: BUSCO_EUKCC_QC {
         publishDir = [
             [
-                path: "${params.outdir}/qc/",
+                path: "${params.outdir}/qc/eukaryotes/",
                 mode: params.publish_dir_mode,
                 failOnError: true,
-            ]
-        ]
-    }
-
-    withName: CAT {
-        publishDir = [
-            [
-                path: "${params.outdir}/intermediate_steps/cleaning_bins/",
-                mode: params.publish_dir_mode,
-                failOnError: false,
             ]
         ]
     }
@@ -75,8 +65,9 @@ process {
     withName: "CHECKM2" {
         publishDir = [
             [
-                path: "${params.outdir}/intermediate_steps/checkm2",
+                path: "${params.outdir}/qc/prokaryotes/checkm2",
                 mode: params.publish_dir_mode,
+                pattern: "*.?sv"
             ]
         ]
     }
@@ -84,22 +75,44 @@ process {
     withName: "CHECKM2_REFINE" {
         publishDir = [
             [
-                path: "${params.outdir}/intermediate_steps/checkm2/refinement",
+                path: "${params.outdir}/intermediate_steps/prokaryotes/checkm2/refinement",
                 mode: params.publish_dir_mode,
+                pattern: "all_stats.csv"
             ]
         ]
     }
 
-    withName: "CHECKM2_BINNER*" {
+    withName: "CHECKM2_BINNER1" {
         publishDir = [
             [
-                path: "${params.outdir}/intermediate_steps/checkm2/binning",
+                path: "${params.outdir}/intermediate_steps/prokaryotes/refinement/checkm2",
                 mode: params.publish_dir_mode,
+                pattern: "binner1_filtered_genomes.tsv"
             ]
         ]
     }
 
-    withName: CHECKM_TABLE_FOR_DREP_GENOMES {
+    withName: "CHECKM2_BINNER2" {
+        publishDir = [
+            [
+                path: "${params.outdir}/intermediate_steps/prokaryotes/refinement/checkm2",
+                mode: params.publish_dir_mode,
+                pattern: "binner2_filtered_genomes.tsv"
+            ]
+        ]
+    }
+
+    withName: "CHECKM2_BINNER3" {
+        publishDir = [
+            [
+                path: "${params.outdir}/intermediate_steps/prokaryotes/refinement/checkm2",
+                mode: params.publish_dir_mode,
+                pattern: "binner3_filtered_genomes.tsv"
+            ]
+        ]
+    }
+
+    withName: CHECKM2_TABLE_FOR_DREP_GENOMES {
         publishDir = [
             [
                 path: "${params.outdir}/",
@@ -140,22 +153,16 @@ process {
     withName: CONSOLIDATE_BINS {
         publishDir = [
             [
-                path: "${params.outdir}/intermediate_steps/refinement/consolidated_bins/",
-                mode: params.publish_dir_mode,
-                failOnError: true,
-                pattern: "consolidated_bins/*"
-            ],
-            [
-                path: "${params.outdir}/intermediate_steps/refinement/",
+                path: "${params.outdir}/intermediate_steps/prokaryotes/refinement/",
                 mode: params.publish_dir_mode,
                 failOnError: true,
                 pattern: "consolidated_stats.tsv"
             ],
             [
-                path: "${params.outdir}/intermediate_steps/refinement/dereplicated_bins/",
+                path: "${params.outdir}/intermediate_steps/prokaryotes/refinement/",
                 mode: params.publish_dir_mode,
                 failOnError: true,
-                pattern: "dereplicated_bins/*"
+                pattern: "dereplicated_list.tsv"
             ],
         ]
     }
@@ -220,21 +227,6 @@ process {
         ]
     }
 
-    withName: DREP_MAGS {
-        publishDir = [
-            [
-                path: "${params.outdir}/intermediate_steps/eukaryotes/drep",
-                mode: params.publish_dir_mode,
-                pattern: "dereplicated_genomes.txt"
-            ],
-            [
-                path: "${params.outdir}/intermediate_steps/eukaryotes/drep/dereplicated_genomes",
-                mode: params.publish_dir_mode,
-                pattern: "drep_output/dereplicated_genomes/*"
-            ]
-        ]
-    }
-
     withName: EUKCC {
         publishDir = [
             [
@@ -267,9 +259,10 @@ process {
     withName: GUNC {
         publishDir = [
             [
-                path: "${params.outdir}/intermediate_steps/qs50/gunc/",
+                path: "${params.outdir}/intermediate_steps/prokaryotes/gunc",
                 mode: params.publish_dir_mode,
                 failOnError: false,
+                pattern: "gunc_contaminated.txt"
             ]
         ]
     }
@@ -277,7 +270,7 @@ process {
     withName: FILTER_QS50 {
         publishDir = [
             [
-                path: "${params.outdir}/intermediate_steps/qs50/",
+                path: "${params.outdir}/intermediate_steps/eukaryotes/qs50/",
                 mode: params.publish_dir_mode,
                 failOnError: true,
                 pattern: "quality_file.csv"
@@ -289,9 +282,10 @@ process {
     withName: GTDBTK {
         publishDir = [
             [
-                path: "${params.outdir}",
+                path: "${params.outdir}/taxonomy/prokaryotes",
                 mode: params.publish_dir_mode,
                 failOnError: true
+                pattern: "gtdbtk_results.tar.gz"
             ]
         ]
     }
@@ -362,7 +356,7 @@ process {
     withName: MODIFY_QUALITY_FILE {
         publishDir = [
             [
-                path: "${params.outdir}/intermediate_steps/qs50",
+                path: "${params.outdir}/intermediate_steps/eukaryotes/qs50",
                 mode: params.publish_dir_mode,
                 failOnError: true,
                 pattern: "aggregated_euk_quality.csv"
@@ -395,6 +389,17 @@ process {
             path: { "${params.outdir}/pipeline_info" },
             mode: params.publish_dir_mode,
             pattern: '*_versions.yml'
+        ]
+    }
+
+    withName: PUBLISH_CLEANED_PROK_BINS' {
+        publishDir = [
+            [
+                path: "${params.outdir}/bins/prokaryotes",
+                mode: params.publish_dir_mode,
+                failOnError: true,
+                pattern: "*.fa"
+            ]
         ]
     }
 }

--- a/modules/local/checkm2/main.nf
+++ b/modules/local/checkm2/main.nf
@@ -10,7 +10,7 @@ process CHECKM2 {
     path checkm2_db
 
     output:
-    tuple val(meta), path(bins), path("all_stats.csv")   , emit: stats
+    tuple val(meta), path(bins), path("${name}_all_stats.csv")   , emit: stats
     tuple val(meta), path("${name}_filtered_genomes")    , emit: filtered_genomes
     tuple val(meta), path("${name}_filtered_genomes.tsv"), emit: filtered_stats
     path "versions.yml"                                  , emit: versions
@@ -28,7 +28,7 @@ process CHECKM2 {
     echo "genome,completeness,contamination" > ${name}_checkm2.tsv
     tail -n +2 ${name}_checkm_output/quality_report.tsv | cut -f1-3 | tr '\\t' ',' >> ${name}_checkm2.tsv
 
-    awk -F, 'NR == 1 {print; next} {OFS=","; \$1 = \$1 ".fa"; print}' ${name}_checkm2.tsv > all_stats.csv 
+    awk -F, 'NR == 1 {print; next} {OFS=","; \$1 = \$1 ".fa"; print}' ${name}_checkm2.tsv > ${name}_all_stats.csv
 
     echo "filter genomes"
     echo "bin\tcompleteness\tcontamination" > ${name}_filtered_genomes.tsv

--- a/modules/local/drep/main.nf
+++ b/modules/local/drep/main.nf
@@ -11,7 +11,7 @@ process DREP {
         'quay.io/biocontainers/drep:3.2.2--pyhdfd78af_0' }"
 
     publishDir(
-        path: "${params.outdir}/intermediate_steps/dRep/${type}/${meta.id}/",
+        path: "${params.outdir}/drep/${type}/${meta.id}/",
         mode: params.publish_dir_mode,
         failOnError: true
     )

--- a/modules/local/mgbinrefinder/consolidate_bins.nf
+++ b/modules/local/mgbinrefinder/consolidate_bins.nf
@@ -27,6 +27,7 @@ process CONSOLIDATE_BINS {
     tuple val(meta), path("consolidated_bins")     , emit: consolidated_bins
     tuple val(meta), path("consolidated_stats.tsv"), emit: consolidated_stats
     tuple val(meta), path("dereplicated_bins/*")   , emit: dereplicated_bins
+    tuple val(meta), path("dereplicated_list.tsv") , emit: dereplicated_list
     path "versions.yml"                            , emit: versions
 
     script:

--- a/modules/local/utils.nf
+++ b/modules/local/utils.nf
@@ -116,3 +116,20 @@ process CHANGE_UNDERSCORE_TO_DOT {
     """
 }
 
+/*
+ * clean reads, change . to _ from contigs
+*/
+process PUBLISH_CLEANED_PROK_BINS {
+
+    tag "${bins}"
+
+    input:
+    path bins
+
+    output:
+    path "*.fa"
+
+    script:
+    """
+    """
+}

--- a/subworkflows/local/clean_and_filter_bins.nf
+++ b/subworkflows/local/clean_and_filter_bins.nf
@@ -1,6 +1,8 @@
 include { CAT as MAG_CLEANUP_CAT    } from '../../modules/local/cat/cat/main'
 include { DETECT_CONTAMINATION      } from '../../modules/local/detect_contamination/main'
 include { GUNC                      } from '../../modules/local/gunc/main'
+include { PUBLISH_CLEANED_PROK_BINS } from '../../modules/local/utils'
+
 /*
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      Run subworkflow cleaning and filtering with GUNC
@@ -41,6 +43,7 @@ workflow CLEAN_AND_FILTER_BINS {
     }).map({ name, cluster_fasta, cluster_gunc ->
         return cluster_fasta
     })
+    PUBLISH_CLEANED_PROK_BINS(filtered_bins)
 
     emit:
     bins        = filtered_bins

--- a/subworkflows/local/euk_mags_generation.nf
+++ b/subworkflows/local/euk_mags_generation.nf
@@ -156,7 +156,7 @@ workflow EUK_MAGS_GENERATION {
         return tuple(meta, list_files)
     }
 
-    CONCATENATE_QUALITY_FILES( combine_quality.map( functionCATCSV ), channel.value("quality_eukcc.csv") )
+    CONCATENATE_QUALITY_FILES( combine_quality.map( functionCATCSV ), "quality_eukcc.csv" )
 
     quality = CONCATENATE_QUALITY_FILES.out.concatenated_result
 
@@ -169,7 +169,7 @@ workflow EUK_MAGS_GENERATION {
     FILTER_QS50( collect_data )
 
     // input: tuple (meta, genomes/*, quality_file)
-    DREP( FILTER_QS50.out.qs50_filtered_genomes, params.euk_drep_args, channel.value('eukaryotes') )
+    DREP( FILTER_QS50.out.qs50_filtered_genomes, params.euk_drep_args, "eukaryotes" )
 
     ch_versions.mix( DREP.out.versions.first() )
 
@@ -177,7 +177,7 @@ workflow EUK_MAGS_GENERATION {
     // TODO: this collectFile is incorrect
     quality_all_csv = quality.map { meta, quality_file -> quality_file }.collectFile(name: "all.csv", newLine: false)
 
-    MODIFY_QUALITY_FILE( quality_all_csv, channel.value("aggregated_euk_quality.csv"))
+    MODIFY_QUALITY_FILE( quality_all_csv, "aggregated_euk_quality.csv")
 
     // ch_versions.mix( MODIFY_QUALITY_FILE.out.versions.first() )
 
@@ -194,7 +194,7 @@ workflow EUK_MAGS_GENERATION {
             return tuple([id: "aggregated"], agg_genomes)
         }
 
-    DREP_MAGS( combine_drep.join( aggregated_quality ), params.euk_drep_args_mags, channel.value('aggregated_eukaryotes') )
+    DREP_MAGS( combine_drep.join( aggregated_quality ), params.euk_drep_args_mags, 'aggregated_eukaryotes' )
 
     ch_versions.mix( DREP_MAGS.out.versions.first() )
 

--- a/subworkflows/local/euk_mags_generation.nf
+++ b/subworkflows/local/euk_mags_generation.nf
@@ -169,7 +169,7 @@ workflow EUK_MAGS_GENERATION {
     FILTER_QS50( collect_data )
 
     // input: tuple (meta, genomes/*, quality_file)
-    DREP( FILTER_QS50.out.qs50_filtered_genomes, params.euk_drep_args, channel.value('euk') )
+    DREP( FILTER_QS50.out.qs50_filtered_genomes, params.euk_drep_args, channel.value('eukaryotes') )
 
     ch_versions.mix( DREP.out.versions.first() )
 
@@ -194,7 +194,7 @@ workflow EUK_MAGS_GENERATION {
             return tuple([id: "aggregated"], agg_genomes)
         }
 
-    DREP_MAGS( combine_drep.join( aggregated_quality ), params.euk_drep_args_mags, channel.value('euk_mags') )
+    DREP_MAGS( combine_drep.join( aggregated_quality ), params.euk_drep_args_mags, channel.value('aggregated_eukaryotes') )
 
     ch_versions.mix( DREP_MAGS.out.versions.first() )
 

--- a/subworkflows/local/prok_mags_generation.nf
+++ b/subworkflows/local/prok_mags_generation.nf
@@ -14,7 +14,7 @@ include { GTDBTK                             } from '../../modules/local/gtdbtk/
 include { CHANGE_UNDERSCORE_TO_DOT           } from '../../modules/local/utils'
 
 
-process CHECKM_TABLE_FOR_DREP_GENOMES {
+process CHECKM2_TABLE_FOR_DREP_GENOMES {
 
     input:
     path(checkm_filtered_genomes_dir)
@@ -79,7 +79,7 @@ workflow PROK_MAGS_GENERATION {
     // -- drep
     prok_drep_args = channel.value('-pa 0.9 -sa 0.95 -nc 0.6 -cm larger -comp 50 -con 5')
 
-    DREP( CHECKM2.out.stats, prok_drep_args, channel.value('prok') )
+    DREP( CHECKM2.out.stats, prok_drep_args, channel.value('prokaryotes') )
 
     // -- coverage -- //
     COVERAGE_RECYCLER( DREP.out.dereplicated_genomes, metabat_depth.collect() )
@@ -99,7 +99,7 @@ workflow PROK_MAGS_GENERATION {
 
     // -- checkm_results_mags.txt -- //
     // Both channels will have only one element
-    CHECKM_TABLE_FOR_DREP_GENOMES(
+    CHECKM2_TABLE_FOR_DREP_GENOMES(
         CHECKM2.out.stats.map { map, bins, stats -> stats },
         DREP.out.dereplicated_genomes_list.map { meta, genomes_list_tsv -> genomes_list_tsv }
     )

--- a/subworkflows/local/prok_mags_generation.nf
+++ b/subworkflows/local/prok_mags_generation.nf
@@ -79,7 +79,7 @@ workflow PROK_MAGS_GENERATION {
     // -- drep
     prok_drep_args = channel.value('-pa 0.9 -sa 0.95 -nc 0.6 -cm larger -comp 50 -con 5')
 
-    DREP( CHECKM2.out.stats, prok_drep_args, channel.value('prokaryotes') )
+    DREP( CHECKM2.out.stats, prok_drep_args, "prokaryotes" )
 
     // -- coverage -- //
     COVERAGE_RECYCLER( DREP.out.dereplicated_genomes, metabat_depth.collect() )


### PR DESCRIPTION
Initially I wanted to make GUNC output be in the pipeline output as 'final bins'. Then I found many places where we return *.fa files and they do not needed. 
I've done some folder changes
- refinement step saved bins, I left only stat tables in output
- checkm2 step saved bins, I left only final stats report
- cleaning step - saved bins but we need bins after GUNC
- drep should not be in intermediate steps 