### PR TITLE
Fix/separate gtdbtk scripts

### DIFF
--- a/bin/tsv_for_genome_upload.py
+++ b/bin/tsv_for_genome_upload.py
@@ -330,10 +330,10 @@ class MAGupload:
         for filename in self.rna:
             if filename.endswith('_rRNAs.out'):
                 genome = filename.split('_rRNAs.out')[0] + '.fa'
-                rrna[genome] = self.check_rna(filename, LIMIT_RRNA)
+                rrna[genome] = self.check_rna(filename, LIMIT_RRNA, 2)
             if filename.endswith('_tRNA_20aa.out'):
                 genome = filename.split('_tRNA_20aa.out')[0] + '.fa'
-                trna[genome] = self.check_rna(filename, LIMIT_TRNA)
+                trna[genome] = self.check_rna(filename, LIMIT_TRNA, 1)
         final_decision = []
         for genome in genomes:
             if genome not in trna or genome not in rrna:
@@ -345,10 +345,10 @@ class MAGupload:
                     final_decision.append('False')
         return final_decision
 
-    def check_rna(self, filename, limit):
+    def check_rna(self, filename, limit, field):
         with open(filename, 'r') as file_in:
             for line in file_in:
-                cur_rna_count = float(line.strip().split('\t')[1])
+                cur_rna_count = float(line.strip().split('\t')[field])
                 if cur_rna_count < limit:
                     return False
         return True

--- a/config/modules.config
+++ b/config/modules.config
@@ -292,6 +292,18 @@ process {
     }
 
 
+    withName: GTDBTK_TO_NCBI_TAXONOMY {
+        publishDir = [
+            [
+                path: "${params.outdir}/taxonomy/prokaryotes",
+                mode: params.publish_dir_mode,
+                failOnError: true,
+                pattern: "ncbi_taxonomy.txt"
+            ]
+        ]
+    }
+
+
     withName: MAXBIN2 {
 
         publishDir = [

--- a/modules/local/gtdbtk/gtdb_to_ncbi_majority_vote/main.nf
+++ b/modules/local/gtdbtk/gtdb_to_ncbi_majority_vote/main.nf
@@ -1,0 +1,47 @@
+process GTDBTK_TO_NCBI_TAXONOMY {
+
+    label 'process_long'
+    container 'quay.io/microbiome-informatics/gtdb-tk:2.3.0.1'
+
+    containerOptions "${ workflow.containerEngine == 'singularity' ?
+        "--bind ${gtdbtk_refdata}:/opt/gtdbtk_refdata":
+        "-v ${gtdbtk_refdata}:/opt/gtdbtk_refdata" }"
+
+    input:
+    path(gtdbtk_results)
+    path(gtdbtk_refdata)
+
+    output:
+    path "ncbi_taxonomy.txt", emit: ncbi_taxonomy
+    path "versions.yml"         , emit: versions
+
+
+    script:
+    """
+    export GTDBTK_DATA_PATH=/opt/gtdbtk_refdata
+
+    echo "Create NCBI taxonomy"
+    gtdb_to_ncbi_majority_vote.py \
+        --gtdbtk_output_dir ${gtdbtk_results} \
+        --output_file ncbi_taxonomy.txt \
+        --ar53_metadata_file ${gtdbtk_refdata}/ar53_metadata_r214.tsv \
+        --bac120_metadata_file ${gtdbtk_refdata}/bac120_metadata_r214.tsv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        gtdb_to_ncbi_majority_vote.py: \$(echo \$(gtdb_to_ncbi_majority_vote.py --version 2>&1) | grep -e "INFO: GTDB to NCBI majority vote v" | sed "s/INFO: GTDB to NCBI majority vote v//")
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    export GTDBTK_DATA_PATH=/opt/gtdbtk_refdata
+
+    touch ncbi_taxonomy.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        gtdb_to_ncbi_majority_vote.py: \$(echo \$(gtdb_to_ncbi_majority_vote.py --version 2>&1) | grep -e "INFO: GTDB to NCBI majority vote v" | sed "s/INFO: GTDB to NCBI majority vote v//")
+    END_VERSIONS
+    """
+}

--- a/modules/local/gtdbtk/gtdb_to_ncbi_majority_vote/main.nf
+++ b/modules/local/gtdbtk/gtdb_to_ncbi_majority_vote/main.nf
@@ -29,7 +29,7 @@ process GTDBTK_TO_NCBI_TAXONOMY {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        gtdb_to_ncbi_majority_vote.py: \$(echo \$(gtdb_to_ncbi_majority_vote.py --version 2>&1) | grep -e "INFO: GTDB to NCBI majority vote v" | sed "s/INFO: GTDB to NCBI majority vote v//")
+        gtdb_to_ncbi_majority_vote.py: \$(echo \$(gtdb_to_ncbi_majority_vote.py -h 2>&1) | head -n 1 | sed "s/gtdb_to_ncbi_majority_vote.py v//; s/:.*//")
     END_VERSIONS
     """
 
@@ -41,7 +41,7 @@ process GTDBTK_TO_NCBI_TAXONOMY {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        gtdb_to_ncbi_majority_vote.py: \$(echo \$(gtdb_to_ncbi_majority_vote.py --version 2>&1) | grep -e "INFO: GTDB to NCBI majority vote v" | sed "s/INFO: GTDB to NCBI majority vote v//")
+        gtdb_to_ncbi_majority_vote.py: \$(echo \$(gtdb_to_ncbi_majority_vote.py -h 2>&1) | head -n 1 | sed "s/gtdb_to_ncbi_majority_vote.py v//; s/:.*//")
     END_VERSIONS
     """
 }

--- a/modules/local/gtdbtk/main.nf
+++ b/modules/local/gtdbtk/main.nf
@@ -13,8 +13,8 @@ process GTDBTK {
 
     output:
     path "gtdbtk_results.tar.gz", emit: gtdbtk_output_tarball
-    path "ncbi_taxonomy.txt", emit: ncbi_taxonomy
-    path "versions.yml"         , emit: versions
+    path "gtdbtk_results",        emit: gtdbtk_output
+    path "versions.yml",          emit: versions
 
 
     script:
@@ -30,15 +30,8 @@ process GTDBTK {
     --skip_ani_screen \
     --out_dir gtdbtk_results
 
-    echo "Create NCBI taxonomy"
-    gtdb_to_ncbi_majority_vote.py \
-        --gtdbtk_output_dir gtdbtk_results \
-        --output_file ncbi_taxonomy.txt \
-        --ar53_metadata_file ${gtdbtk_refdata}/ar53_metadata_r214.tsv \
-        --bac120_metadata_file ${gtdbtk_refdata}/bac120_metadata_r214.tsv
-
     echo "Compress GTDB-Tk"
-    tar -czf gtdbtk_results.tar.gz gtdbtk_results
+    tar -czf gtdbtk_results.tar.gz -C gtdbtk_results .
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -55,9 +48,8 @@ process GTDBTK {
     mkdir -p gtdbtk_results/classify
     touch gtdbtk_results/classify/gtdbtk.bac120.summary.tsv
     touch gtdbtk_results/classify/gtdbtk.ar122.summary.tsv
-    touch ncbi_taxonomy.txt
 
-    tar -czf gtdbtk_results.tar.gz gtdbtk_results
+    tar -czf gtdbtk_results.tar.gz -C gtdbtk_results .
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/subworkflows/local/prok_mags_generation.nf
+++ b/subworkflows/local/prok_mags_generation.nf
@@ -11,6 +11,7 @@ include { DREP                               } from '../../modules/local/drep/ma
 include { COVERAGE_RECYCLER                  } from '../../modules/local/coverage_recycler/main'
 include { DETECT_RRNA                        } from '../../modules/local/detect_rrna/main'
 include { GTDBTK                             } from '../../modules/local/gtdbtk/main'
+include { GTDBTK_TO_NCBI_TAXONOMY            } from '../../modules/local/gtdbtk/gtdb_to_ncbi_majority_vote/main'
 include { CHANGE_UNDERSCORE_TO_DOT           } from '../../modules/local/utils'
 include { GZIP as GZIP_MAGS                  } from '../../modules/local/utils'
 
@@ -109,8 +110,9 @@ workflow PROK_MAGS_GENERATION {
 
     // -- Taxonomy --//
     GTDBTK( CHANGE_UNDERSCORE_TO_DOT.out.return_files.collect(), gtdbtk_db )
-
     ch_versions = ch_versions.mix( GTDBTK.out.versions.first() )
+    GTDBTK_TO_NCBI_TAXONOMY(GTDBTK.out.gtdbtk_output, gtdbtk_db)
+    ch_versions = ch_versions.mix( GTDBTK_TO_NCBI_TAXONOMY.out.versions.first() )
 
     // -- checkm_results_mags.txt -- //
     // Both channels will have only one element
@@ -129,6 +131,6 @@ workflow PROK_MAGS_GENERATION {
     stats = CHECKM2_TABLE_FOR_DREP_GENOMES.out.checkm_results_mags
     coverage = COVERAGE_RECYCLER.out.mag_coverage.map{ meta, coverage_file -> coverage_file }.collect()
     rna = rna_out
-    taxonomy = GTDBTK.out.ncbi_taxonomy
+    taxonomy = GTDBTK_TO_NCBI_TAXONOMY.out.ncbi_taxonomy
     versions = ch_versions
 }

--- a/subworkflows/local/prok_mags_generation.nf
+++ b/subworkflows/local/prok_mags_generation.nf
@@ -103,9 +103,7 @@ workflow PROK_MAGS_GENERATION {
         rfam_rrna_models
     )
     rna_out = Channel.empty()
-    rna_out = rna_out.mix( DETECT_RRNA.out.rrna_out_files.collect() )
-    rna_out = rna_out.mix( DETECT_RRNA.out.trna_out_files.collect() )
-
+    rna_out = rna_out.mix( DETECT_RRNA.out.rrna_out_files.collect(), DETECT_RRNA.out.trna_out_files.collect()  )
     ch_versions = ch_versions.mix( DETECT_RRNA.out.versions.first() )
 
     // -- Taxonomy --//
@@ -130,7 +128,7 @@ workflow PROK_MAGS_GENERATION {
     genomes = GZIP_MAGS.out.compressed.collect()
     stats = CHECKM2_TABLE_FOR_DREP_GENOMES.out.checkm_results_mags
     coverage = COVERAGE_RECYCLER.out.mag_coverage.map{ meta, coverage_file -> coverage_file }.collect()
-    rna = rna_out
+    rna = rna_out.collect()
     taxonomy = GTDBTK_TO_NCBI_TAXONOMY.out.ncbi_taxonomy
     versions = ch_versions
 }


### PR DESCRIPTION
Separated taxonomy convertor from gtdbtk. 
I updated container https://github.com/EBI-Metagenomics/containers/pull/16 
I left gtdb-tk for v2.3.0 (actually they released v2.3.2 but without fix in convertor). ncbi_taxonomy_convertor step uses updated container v2.3.0.1