### PR TITLE
Add exitcode check for unbinned assembly in MaxBin

### DIFF
--- a/bin/rename_maxbin.py
+++ b/bin/rename_maxbin.py
@@ -26,6 +26,6 @@ def main():
         filename = os.path.basename(i)
         number = int(filename.split('.')[1])
         new_filename = f"{args.accession}_maxbin2_{number}.fa"
-        shutil.copy(os.path.join(args.bins, i), os.path.join(args.outdir, new_filename))
+        shutil.move(os.path.join(args.bins, i), os.path.join(args.outdir, new_filename))
 if __name__ == "__main__":
     main()

--- a/bin/rename_maxbin.py
+++ b/bin/rename_maxbin.py
@@ -13,8 +13,7 @@ def main():
     parser.add_argument("-o", "--output", dest="outdir", type=str, help="Output directory")
     parser.add_argument("--bins",
         dest="bins",
-        nargs="+",
-        help="Maxbin bins list"
+        help="Maxbin bins folder"
     )
     parser.add_argument("-v", "--version", dest="version", type=str, help="Tool version")
     parser.add_argument("-a", "--accession", dest="accession", type=str, help="Run accession")
@@ -22,11 +21,11 @@ def main():
     args = parser.parse_args()
     if not os.path.exists(args.outdir):
         os.mkdir(args.outdir)
-    for i in args.bins:
+    for i in os.listdir(args.bins):
         # Define the regular expression pattern
         filename = os.path.basename(i)
         number = int(filename.split('.')[1])
         new_filename = f"{args.accession}_maxbin2_{number}.fa"
-        shutil.move(i, os.path.join(args.outdir, new_filename))
+        shutil.copy(os.path.join(args.bins, i), os.path.join(args.outdir, new_filename))
 if __name__ == "__main__":
     main()

--- a/modules/nf-core/maxbin2/main.nf
+++ b/modules/nf-core/maxbin2/main.nf
@@ -46,6 +46,8 @@ process MAXBIN2 {
         -out $prefix
 
     MAXBIN_EXITCODE="\$?"
+    set -e
+
     echo "Exit code \$MAXBIN_EXITCODE"
     if [ "\$MAXBIN_EXITCODE" == "255" ]; then
         echo "Maxbin2 exit code \$MAXBIN_EXITCODE"
@@ -65,13 +67,10 @@ process MAXBIN2 {
             fi
         fi
     fi
-    sleep 5
 
     echo "Collect folder"
     mv $prefix*.fasta maxbin_output/
     echo "Compress files"
     gzip *.noclass *.tooshort *log *.marker
-
-    set -e
     """
 }

--- a/modules/nf-core/maxbin2/main.nf
+++ b/modules/nf-core/maxbin2/main.nf
@@ -11,12 +11,12 @@ process MAXBIN2 {
     tuple val(meta), path(contigs), path(reads), path(abund)
 
     output:
-    tuple val(meta), path("*.fasta")   , emit: binned_fastas
-    tuple val(meta), path("*.summary")    , emit: summary
+    tuple val(meta), path("maxbin_output"), emit: binned_fastas
+    tuple val(meta), path("*.summary")    , emit: summary,  optional: true
     tuple val(meta), path("*.log.gz")     , emit: log
-    tuple val(meta), path("*.marker.gz")  , emit: marker_counts
-    tuple val(meta), path("*.noclass.gz") , emit: unbinned_fasta
-    tuple val(meta), path("*.tooshort.gz"), emit: tooshort_fasta
+    tuple val(meta), path("*.marker.gz")  , emit: marker_counts, optional: true
+    tuple val(meta), path("*.noclass.gz") , emit: unbinned_fasta, optional: true
+    tuple val(meta), path("*.tooshort.gz"), emit: tooshort_fasta, optional: true
     tuple val(meta), path("*_bin.tar.gz") , emit: marker_bins , optional: true
     tuple val(meta), path("*_gene.tar.gz"), emit: marker_genes, optional: true
     path "versions.yml"                   , emit: versions
@@ -30,6 +30,14 @@ process MAXBIN2 {
     def associate_files = reads ? "-reads $reads" : "-abund $abund"
     """
 
+    mkdir -p maxbin_output
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        maxbin2: \$( run_MaxBin.pl -v | head -n 1 | sed 's/MaxBin //' )
+    END_VERSIONS
+
+    set +e
     run_MaxBin.pl \\
         -contig $contigs \\
         $associate_files \\
@@ -37,11 +45,33 @@ process MAXBIN2 {
         $args \\
         -out $prefix
 
+    MAXBIN_EXITCODE="\$?"
+    echo "Exit code \$MAXBIN_EXITCODE"
+    if [ "\$MAXBIN_EXITCODE" == "255" ]; then
+        echo "Maxbin2 exit code \$MAXBIN_EXITCODE"
+        if [ ! -e "${prefix}.log" ]; then
+            echo "maxbin.log does not exist. Exit"
+            echo "Error" >&2
+            exit \$MAXBIN_EXITCODE
+        else
+            echo "maxbin.log exists -> checking for not enough marker genes error"
+            if grep -q "Marker gene search reveals that the dataset cannot be binned (the medium of marker gene number <= 1). Program stop." "${prefix}.log"; then
+                echo "Not enough marker genes"
+                gzip *log
+                exit 0
+            else
+                echo "Unknown problem. Exit"
+                exit \$MAXBIN_EXITCODE
+            fi
+        fi
+    fi
+    sleep 5
+
+    echo "Collect folder"
+    mv $prefix*.fasta maxbin_output/
+    echo "Compress files"
     gzip *.noclass *.tooshort *log *.marker
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        maxbin2: \$( run_MaxBin.pl -v | head -n 1 | sed 's/MaxBin //' )
-    END_VERSIONS
+    set -e
     """
 }

--- a/subworkflows/local/mag_binning.nf
+++ b/subworkflows/local/mag_binning.nf
@@ -58,12 +58,9 @@ workflow BINNING {
 
         MAXBIN2 ( ch_maxbin2_input )
 
-        RENAME_MAXBIN ( MAXBIN2.out.binned_fastas )
-        empty_output_maxbin = ch_maxbin2_input.map{meta, contigs, reads, abund -> return tuple(meta, [])}
-
-        maxbin_output = RENAME_MAXBIN.out.renamed_bins.ifEmpty(empty_output_maxbin).map { meta, bins ->
-            [meta.subMap('id', 'erz'), bins]
-        }
+        RENAME_MAXBIN ( MAXBIN2.out.binned_fastas )    // output can be empty folder
+        maxbin_output = RENAME_MAXBIN.out.renamed_bins.map { meta, bins ->
+            [ meta.subMap('id', 'erz'), bins ]}
 
         ch_versions = ch_versions.mix( CONVERT_DEPTHS.out.versions.first() )
         ch_versions = ch_versions.mix( MAXBIN2.out.versions.first() )
@@ -76,9 +73,8 @@ workflow BINNING {
 
         METABAT2_METABAT2 ( ch_metabat2_input )
 
-        metabat_output = METABAT2_METABAT2.out.fasta.ifEmpty(empty_output_metabat).map { meta, bins ->
-            [ meta.subMap('id', 'erz'), bins ]
-        }
+        metabat_output = METABAT2_METABAT2.out.fasta.map { meta, bins ->
+            [ meta.subMap('id', 'erz'), bins ]}
 
         ch_versions = ch_versions.mix(METABAT2_METABAT2.out.versions.first())
     }
@@ -92,13 +88,10 @@ workflow BINNING {
             bams: [ meta_extended, bams, bais ]
         }.set { ch_concoct_input }
 
-        empty_output_concoct = ch_concoct_input.bins.map{meta, _ -> return tuple(meta, [])}
-
         FASTA_BINNING_CONCOCT( ch_concoct_input.bins, ch_concoct_input.bams )
 
-        concoct_output = FASTA_BINNING_CONCOCT.out.bins.ifEmpty(empty_output_concoct).map { meta, bins ->
-            [ meta.subMap('id', 'erz'), bins ]
-        }
+        concoct_output = FASTA_BINNING_CONCOCT.out.bins.map { meta, bins ->
+            [ meta.subMap('id', 'erz'), bins ]}
 
         ch_versions = ch_versions.mix( FASTA_BINNING_CONCOCT.out.versions.first() )
     }

--- a/workflows/genomes_generation.nf
+++ b/workflows/genomes_generation.nf
@@ -177,9 +177,9 @@ workflow GGP {
     if ( !params.skip_prok ) {
 
         // input: tuple( meta, concoct, metabat, maxbin, depth_file)
-        collected_binners_and_depth = concoct_collected_bins.join( maxbin_collected_bins ) \
-            .join( metabat_collected_bins ) \
-            .join( BINNING.out.metabat2depths )
+        collected_binners_and_depth = concoct_collected_bins.join( maxbin_collected_bins, remainder: true ) \
+            .join( metabat_collected_bins, remainder: true ) \
+            .join( BINNING.out.metabat2depths, remainder: true )
 
         PROK_MAGS_GENERATION(
             collected_binners_and_depth,


### PR DESCRIPTION
```
Command exit status:
  255

Command output:
  MaxBin 2.2.7
  Input contig: ERR594380.fasta
  Located abundance file [ERR594380_mb2_depth.txt]
  Thread: 6
  Min contig length: 1500
  out header: maxbin2-ERR594380
  Searching against 107 marker genes to find starting seed contigs for [ERR594380.fasta]...
  Running FragGeneScan....
  Running HMMER hmmsearch....
  Try harder to dig out marker genes from contigs.
  Marker gene search reveals that the dataset cannot be binned (the medium of marker gene number <= 1). Program stop.
```