### PR TITLE
Fix renaming process for broken fastq files

### DIFF
--- a/modules/local/align_bwa/main.nf
+++ b/modules/local/align_bwa/main.nf
@@ -46,11 +46,7 @@ process ALIGNMENT {
     if ( meta.single_end ) {
         input_reads = "${reads[0]}";
     } else {
-        if (reads[0].name.contains("_1")) {
-            input_reads = "${reads[0]} ${reads[1]}"
-        } else {
-            input_reads = "${reads[1]} ${reads[0]}"
-        }
+        input_reads = "${reads[0]} ${reads[1]}"
     }
 
     def samtools_args = ""

--- a/modules/local/align_bwa/main.nf
+++ b/modules/local/align_bwa/main.nf
@@ -43,7 +43,7 @@ process ALIGNMENT {
 
     script:
     def input_reads = "";
-    if ( reads.collect().size() == 1 ) {
+    if ( meta.single_end ) {
         input_reads = "${reads[0]}";
     } else {
         if (reads[0].name.contains("_1")) {

--- a/modules/local/genome_uploader/main.nf
+++ b/modules/local/genome_uploader/main.nf
@@ -48,7 +48,7 @@ process PREPARE_TSV_FOR_UPLOADER {
         ${args_tax_proks} \
         --metagenome '$params.metagenome' \
         --biomes '${params.biomes}' \
-        --absolute-path $params.outdir
+        --absolute-path "$params.launchDir/$params.outdir"
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/genome_uploader/main.nf
+++ b/modules/local/genome_uploader/main.nf
@@ -48,7 +48,7 @@ process PREPARE_TSV_FOR_UPLOADER {
         ${args_tax_proks} \
         --metagenome '$params.metagenome' \
         --biomes '${params.biomes}' \
-        --absolute-path "$params.launchDir/$params.outdir"
+        --absolute-path "${launchDir}/$params.outdir"
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/utils.nf
+++ b/modules/local/utils.nf
@@ -100,18 +100,17 @@ process ERR_TO_ERZ {
     else {
         """
         echo "read1"
-        seqkit sana ${input_ch[0]} | seqkit replace -p ${meta.id} -r ${meta.erz} -o ${meta.id}_tmp_1.fastq.gz
+        seqkit sana ${input_ch[0]} | seqkit replace -p ${meta.id} -r ${meta.erz} -o ${meta.id}_changed_1.fastq.gz
 
         echo "read2"
-        seqkit sana ${input_ch[1]} | seqkit replace -p ${meta.id} -r ${meta.erz} -o ${meta.id}_tmp_2.fastq.gz
+        seqkit sana ${input_ch[1]} | seqkit replace -p ${meta.id} -r ${meta.erz} -o ${meta.id}_changed_2.fastq.gz
 
-        echo "sync read1"
-        seqkit sana -i ${meta.id}_tmp_1.fastq.gz ${meta.id}_tmp_2.fastq.gz -o ${meta.id}_changed_1.fastq.gz
+        echo "sync read1 and read2"
+        seqkit pair -1 ${meta.id}_changed_1.fastq.gz -2 ${meta.id}_changed_2.fastq.gz -O result
 
-        echo "sync read2"
-        seqkit sana -i ${meta.id}_tmp_2.fastq.gz ${meta.id}_tmp_1.fastq.gz -o ${meta.id}_changed_2.fastq.gz
-
-        rm ${meta.id}_tmp_1.fastq.gz ${meta.id}_tmp_2.fastq.gz
+        mv result/${meta.id}_changed_1.fastq.gz ${meta.id}_changed_1.fastq.gz
+        mv result/${meta.id}_changed_2.fastq.gz ${meta.id}_changed_2.fastq.gz
+        rm -rf result
 
         echo "Done"
 

--- a/modules/local/utils.nf
+++ b/modules/local/utils.nf
@@ -82,14 +82,14 @@ process ERR_TO_ERZ {
     tuple val(meta), path(reads)
 
     output:
-    tuple val(meta), path("*changed*.*.gz"), emit: modified_reads
+    tuple val(meta), path("*sanitized*.*.gz"), emit: modified_reads
     path "versions.yml"                       , emit: versions
 
     script:
     input_ch = reads.collect()
     if (meta.single_end ) {
         """
-        seqkit sana ${input_ch[0]} | seqkit replace -p ${meta.id} -r ${meta.erz} -o ${meta.id}_changed.fastq.gz
+        seqkit sana ${input_ch[0]} | seqkit replace -p ${meta.id} -r ${meta.erz} -o ${meta.id}_sanitized.fastq.gz
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
@@ -100,16 +100,16 @@ process ERR_TO_ERZ {
     else {
         """
         echo "read1"
-        seqkit sana ${input_ch[0]} | seqkit replace -p ${meta.id} -r ${meta.erz} -o ${meta.id}_changed_1.fastq.gz
+        seqkit sana ${input_ch[0]} | seqkit replace -p ${meta.id} -r ${meta.erz} -o ${meta.id}_sanitized_1.fastq.gz
 
         echo "read2"
-        seqkit sana ${input_ch[1]} | seqkit replace -p ${meta.id} -r ${meta.erz} -o ${meta.id}_changed_2.fastq.gz
+        seqkit sana ${input_ch[1]} | seqkit replace -p ${meta.id} -r ${meta.erz} -o ${meta.id}_sanitized_2.fastq.gz
 
         echo "sync read1 and read2"
-        seqkit pair -1 ${meta.id}_changed_1.fastq.gz -2 ${meta.id}_changed_2.fastq.gz -O result
+        seqkit pair -1 ${meta.id}_sanitized_1.fastq.gz -2 ${meta.id}_sanitized_2.fastq.gz -O result
 
-        mv result/${meta.id}_changed_1.fastq.gz ${meta.id}_changed_1.fastq.gz
-        mv result/${meta.id}_changed_2.fastq.gz ${meta.id}_changed_2.fastq.gz
+        mv result/${meta.id}_sanitized_1.fastq.gz ${meta.id}_sanitized_1.fastq.gz
+        mv result/${meta.id}_sanitized_2.fastq.gz ${meta.id}_sanitized_2.fastq.gz
         rm -rf result
 
         echo "Done"

--- a/modules/local/utils.nf
+++ b/modules/local/utils.nf
@@ -87,7 +87,7 @@ process ERR_TO_ERZ {
 
     script:
     input_ch = reads.collect()
-    if (input_ch.size() == 1 ) {
+    if (meta.single_end ) {
         """
         seqkit sana ${input_ch[0]} | seqkit replace -p ${meta.id} -r ${meta.erz} -o ${meta.id}_changed.fastq.gz
 
@@ -97,13 +97,21 @@ process ERR_TO_ERZ {
         END_VERSIONS
         """
     }
-    else if (input_ch.size() == 2 ) {
+    else {
         """
         echo "read1"
-        seqkit sana ${input_ch[0]} | seqkit replace -p ${meta.id} -r ${meta.erz} -o ${meta.id}_changed_1.fastq.gz
+        seqkit sana ${input_ch[0]} | seqkit replace -p ${meta.id} -r ${meta.erz} -o ${meta.id}_tmp_1.fastq.gz
 
         echo "read2"
-        seqkit sana ${input_ch[1]} | seqkit replace -p ${meta.id} -r ${meta.erz} -o ${meta.id}_changed_2.fastq.gz
+        seqkit sana ${input_ch[1]} | seqkit replace -p ${meta.id} -r ${meta.erz} -o ${meta.id}_tmp_2.fastq.gz
+
+        echo "sync read1"
+        seqkit sana -i ${meta.id}_tmp_1.fastq.gz ${meta.id}_tmp_2.fastq.gz -o ${meta.id}_changed_1.fastq.gz
+
+        echo "sync read2"
+        seqkit sana -i ${meta.id}_tmp_2.fastq.gz ${meta.id}_tmp_1.fastq.gz -o ${meta.id}_changed_2.fastq.gz
+
+        rm ${meta.id}_tmp_1.fastq.gz ${meta.id}_tmp_2.fastq.gz
 
         echo "Done"
 

--- a/modules/local/utils.nf
+++ b/modules/local/utils.nf
@@ -89,7 +89,7 @@ process ERR_TO_ERZ {
     input_ch = reads.collect()
     if (input_ch.size() == 1 ) {
         """
-        seqkit replace -p ${meta.id} -r ${meta.erz} ${input_ch[0]} | gzip > ${meta.id}_changed.fastq.gz
+        seqkit sana ${input_ch[0]} | seqkit replace -p ${meta.id} -r ${meta.erz} -o ${meta.id}_changed.fastq.gz
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
@@ -100,10 +100,10 @@ process ERR_TO_ERZ {
     else if (input_ch.size() == 2 ) {
         """
         echo "read1"
-        seqkit replace -p ${meta.id} -r ${meta.erz} ${input_ch[0]} | gzip > ${meta.id}_changed_1.fastq.gz
+        seqkit sana ${input_ch[0]} | seqkit replace -p ${meta.id} -r ${meta.erz} -o ${meta.id}_changed_1.fastq.gz
 
         echo "read2"
-        seqkit replace -p ${meta.id} -r ${meta.erz} ${input_ch[1]} | gzip > ${meta.id}_changed_2.fastq.gz
+        seqkit sana ${input_ch[1]} | seqkit replace -p ${meta.id} -r ${meta.erz} -o ${meta.id}_changed_2.fastq.gz
 
         echo "Done"
 

--- a/modules/local/utils.nf
+++ b/modules/local/utils.nf
@@ -93,7 +93,7 @@ process ERR_TO_ERZ {
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
-            seqkit: \$(seqkit --version 2>&1 | sed 's/seqkit //g')
+            seqkit: \$(seqkit version 2>&1 | sed 's/seqkit //g')
         END_VERSIONS
         """
     }
@@ -116,7 +116,7 @@ process ERR_TO_ERZ {
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
-            seqkit: \$(seqkit --version 2>&1 | sed 's/seqkit //g')
+            seqkit: \$(seqkit version 2>&1 | sed 's/seqkit //g')
         END_VERSIONS
         """
     }

--- a/modules/nf-core/fastp/main.nf
+++ b/modules/nf-core/fastp/main.nf
@@ -26,7 +26,7 @@ process FASTP {
     task.ext.when == null || task.ext.when
 
     script:
-    def single_end = reads.collect().size() == 1
+    def single_end = meta.single_end
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def adapter_list = adapter_fasta ? "--adapter_fasta ${adapter_fasta}" : ""
@@ -103,7 +103,7 @@ process FASTP {
 
     stub:
     def layout = ""
-    if (reads.collect().size() == 1) {
+    if (meta.single_end) {
         layout = 'SE'
     }
     else {

--- a/modules/nf-core/samtools/bam2fq/main.nf
+++ b/modules/nf-core/samtools/bam2fq/main.nf
@@ -4,12 +4,11 @@ process SAMTOOLS_BAM2FQ {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samtools:1.17--h00cdaf9_0' :
-        'biocontainers/samtools:1.17--h00cdaf9_0' }"
+        'https://depot.galaxyproject.org/singularity/samtools:1.19.2--h50ea8bc_0' :
+        'biocontainers/samtools:1.19.2--h50ea8bc_0' }"
 
     input:
-    tuple val(meta), path(bam)
-    val split
+    tuple val(meta), path(inputbam)
 
     output:
     tuple val(meta), path("*.fq.gz"), emit: reads
@@ -22,12 +21,17 @@ process SAMTOOLS_BAM2FQ {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
 
-    if (!split) {
+    if (split) {
         """
         samtools \\
             bam2fq \\
+            $args \\
             -@ $task.cpus \\
-            $bam | gzip --no-name > ${prefix}.bwa.fq.gz
+            -1 ${prefix}_1.fq.gz \\
+            -2 ${prefix}_2.fq.gz \\
+            -0 ${prefix}_other.fq.gz \\
+            -s ${prefix}_singleton.fq.gz \\
+            $inputbam
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
@@ -38,12 +42,9 @@ process SAMTOOLS_BAM2FQ {
         """
         samtools \\
             bam2fq \\
+            $args \\
             -@ $task.cpus \\
-            -1 ${prefix}_1.bwa.fq.gz \\
-            -2 ${prefix}_2.bwa.fq.gz \\
-            -0 /dev/null \\
-            -s /dev/null \\
-            $bam
+            $inputbam | gzip --no-name > ${prefix}_interleaved.fq.gz
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":

--- a/modules/nf-core/samtools/bam2fq/main.nf
+++ b/modules/nf-core/samtools/bam2fq/main.nf
@@ -39,7 +39,6 @@ process SAMTOOLS_BAM2FQ {
             samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
         END_VERSIONS
 
-        rm $inputbam
         """
     } else {
         """

--- a/modules/nf-core/samtools/bam2fq/main.nf
+++ b/modules/nf-core/samtools/bam2fq/main.nf
@@ -20,8 +20,9 @@ process SAMTOOLS_BAM2FQ {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def single_end = meta.single_end
 
-    if (split) {
+    if (!single_end) {
         """
         samtools \\
             bam2fq \\
@@ -37,6 +38,8 @@ process SAMTOOLS_BAM2FQ {
         "${task.process}":
             samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
         END_VERSIONS
+
+        rm $inputbam
         """
     } else {
         """

--- a/subworkflows/local/decontamination.nf
+++ b/subworkflows/local/decontamination.nf
@@ -22,7 +22,7 @@ workflow DECONTAMINATION {
 
     ALIGNMENT( to_align, false )
 
-    SAMTOOLS_BAM2FQ( ALIGNMENT.out.bam.map { meta, ref_fasta, bam, bai -> [ meta, bam ] }, true )
+    SAMTOOLS_BAM2FQ( ALIGNMENT.out.bam.map { meta, ref_fasta, bam, bai -> [ meta, bam ] }, reads.map { meta, reads -> meta.single_end == false } )
 
     ch_versions = ch_versions.mix(ALIGNMENT.out.versions.first())
     ch_versions = ch_versions.mix(SAMTOOLS_BAM2FQ.out.versions.first())

--- a/subworkflows/local/decontamination.nf
+++ b/subworkflows/local/decontamination.nf
@@ -22,7 +22,7 @@ workflow DECONTAMINATION {
 
     ALIGNMENT( to_align, false )
 
-    SAMTOOLS_BAM2FQ( ALIGNMENT.out.bam.map { meta, ref_fasta, bam, bai -> [ meta, bam ] }, reads.map { meta, reads -> meta.single_end == false } )
+    SAMTOOLS_BAM2FQ( ALIGNMENT.out.bam.map { meta, ref_fasta, bam, bai -> [ meta, bam ] } )
 
     ch_versions = ch_versions.mix(ALIGNMENT.out.versions.first())
     ch_versions = ch_versions.mix(SAMTOOLS_BAM2FQ.out.versions.first())

--- a/subworkflows/local/process_input_files.nf
+++ b/subworkflows/local/process_input_files.nf
@@ -29,7 +29,7 @@ workflow PROCESS_INPUT {
     // it is required for next step FASTP that SE reads should be also in list
     reads_changed = ERR_TO_ERZ.out.modified_reads.map{meta, reads ->
                                                             result = [meta]
-                                                            if (reads.collect().size() == 2) {
+                                                            if (!meta.single_end) {
                                                                 result.add(reads) }
                                                             else {
                                                                 result.add([reads]) }

--- a/subworkflows/local/qc_and_merge.nf
+++ b/subworkflows/local/qc_and_merge.nf
@@ -19,8 +19,8 @@ workflow QC_AND_MERGE_READS {
     ch_multiqc_files      = Channel.empty()
 
     reads.branch {
-        single: it[1].collect().size() == 1
-        paired: it[1].collect().size() == 2
+        single: it[0].single_end
+        paired: !it[0].single_end
     }.set {
         ch_input_for_fastp
     }

--- a/workflows/genomes_generation.nf
+++ b/workflows/genomes_generation.nf
@@ -101,14 +101,14 @@ workflow GGP {
     // ---- combine data for reads and contigs pre-processing ---- //
     groupReads = { meta, assembly, fq1, fq2 ->
         if (fq2 == []) {
-            return tuple(meta, assembly, [fq1])
+            return tuple(meta + [single_end: true], assembly, [fq1])
         }
         else {
-            return tuple(meta, assembly, [fq1, fq2])
+            return tuple(meta + [single_end: false], assembly, [fq1, fq2])
         }
     }
     assembly_and_runs = Channel.fromSamplesheet("samplesheet", header: true, sep: ',').map(groupReads) // [ meta, assembly_file, [raw_reads] ]
-
+    assembly_and_runs.view()
     // ---- pre-processing ---- //
     PROCESS_INPUT( assembly_and_runs ) // output: [ meta, assembly, [raw_reads] ]
 

--- a/workflows/genomes_generation.nf
+++ b/workflows/genomes_generation.nf
@@ -108,7 +108,7 @@ workflow GGP {
         }
     }
     assembly_and_runs = Channel.fromSamplesheet("samplesheet", header: true, sep: ',').map(groupReads) // [ meta, assembly_file, [raw_reads] ]
-    assembly_and_runs.view()
+
     // ---- pre-processing ---- //
     PROCESS_INPUT( assembly_and_runs ) // output: [ meta, assembly, [raw_reads] ]
 

--- a/workflows/genomes_generation.nf
+++ b/workflows/genomes_generation.nf
@@ -144,6 +144,7 @@ workflow GGP {
     concoct_collected_bins = BINNING.out.concoct_bins.map( collectBinsFolder )
     metabat_collected_bins = BINNING.out.metabat_bins.map( collectBinsFolder )
     maxbin_collected_bins = BINNING.out.maxbin_bins.map( collectBinsFolder )
+    binning_depths = BINNING.out.metabat2depths
 
     if ( !params.skip_euk ) {
 
@@ -175,11 +176,10 @@ workflow GGP {
     }
 
     if ( !params.skip_prok ) {
-
         // input: tuple( meta, concoct, metabat, maxbin, depth_file)
         collected_binners_and_depth = concoct_collected_bins.join( maxbin_collected_bins, remainder: true ) \
             .join( metabat_collected_bins, remainder: true ) \
-            .join( BINNING.out.metabat2depths, remainder: true )
+            .join( binning_depths, remainder: true )
 
         PROK_MAGS_GENERATION(
             collected_binners_and_depth,


### PR DESCRIPTION
:heavy_exclamation_mark: **- Fixes for bad fastq files:**

Some fastq files contain bad content.
Swapping fastp step to the begining of pipeline didn't help. fastp raises error:
```
Detecting adapter sequence for read1...
No adapter detected for read1

Detecting adapter sequence for read2...
No adapter detected for read2

ERROR: sequence and quality have different length:
@ERR599122.77917766 H4:D1C0BACXX:5:1310:6949:60178/1
CACTCAGAGCAGTACTCATCTGGATTTGTACAGAGAGTGTCAGAGTACTAATTTCTTGGTACATCCAGACATGATGTCAAAGAAGAGCACTGTTCGATTCT
+
CCCFFFFFHHHHHJJJJJJJJJIIIJJIHIJJJIJGJHHDHIJJJDHIJJIJAAAAACGCTCAACCACTAATAAATGACTTGGCCAATCCACCG
ERROR: sequence and quality have different length
```

I added `seqkit sana` command to leave only good reads

.command.log now contains all "bad" lines:

`[INFO]ESC[0m File: ERR599122_1.fastq.gz Pass records: 77917847  Discarded lines: 3658493`

 **16G**  ERR599122_changed_2.fastq.gz
 **6.8G**  ERR599122_changed_1.fastq.gz

I also added one step to sync reads after `sana` because fastp (next step) doesn't support different number of reads in input PE files.
_If you know how to make those seqkit commands faster/efficient - let me know!_

:heavy_exclamation_mark: **- Fixes for SE support with single_end**
Another fix is support of `meta.single_end` field for all checks for PE/SE