### PR TITLE
make pipeline support compressed assemblies as input

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -15,7 +15,7 @@
       },
       "assembly": {
         "type": "string",
-        "pattern": "^\\S+\\.(fa|fasta)$",
+        "pattern": "^\\S+\\.(fa.gz|fasta.gz)$",
         "errorMessage": "The assembly needs to be a fasta file."
       },
       "fastq_1": {

--- a/download_data/fetch_data.sh
+++ b/download_data/fetch_data.sh
@@ -7,17 +7,12 @@ function FetchReads {
   bsub -I -q production "bash fetch-reads-tool.sh -v -p $READS_ACC -d ${CATALOGUE_PATH}/Raw_reads/" --run-list ${CATALOGUE_PATH}/runs.tsv
 }
 
+
 function FetchAssemblies {
   echo 'Fetching assemblies...'
   . "/hps/software/users/rdf/metagenomics/service-team/repos/mi-automation/team_environments/codon/mitrc.sh"
   mitload fetchtool
   bsub -I -q production "bash fetch-assemblies-tool.sh -v -p $SAMPLE -d ${CATALOGUE_PATH}/Assemblies/"
-}
-
-
-function Unzip {
-  echo 'Unzipping...'
-  gunzip -f ${CATALOGUE_PATH}/Assemblies/${SAMPLE}/raw/*gz
 }
 
 
@@ -45,10 +40,11 @@ function Rename {
     then
       export OLD=$(echo $line | cut -d ',' -f1)
       export NEW=$(echo $line | cut -d ',' -f2)
-      mv ${CATALOGUE_PATH}/Assemblies/${SAMPLE}/raw/${NEW}.fasta ${CATALOGUE_PATH}/Assemblies/${SAMPLE}/raw/${OLD}.fasta
+      mv ${CATALOGUE_PATH}/Assemblies/${SAMPLE}/raw/${NEW}.fasta.gz ${CATALOGUE_PATH}/Assemblies/${SAMPLE}/raw/${OLD}.fasta.gz
     fi
   done < $CONVERT
 }
+
 
 function GenerateSamplesheet {
   echo "Generate samplesheet"
@@ -88,7 +84,6 @@ mkdir -p "$CATALOGUE_PATH"
 
 if [[ $SKIP_FETCH == 'false' ]]; then
   FetchAssemblies
-  Unzip
 fi
 
 RunRenamingScript

--- a/modules/local/utils.nf
+++ b/modules/local/utils.nf
@@ -6,17 +6,18 @@
 process GUNZIP {
 
     label 'process_low'
+    tag "$meta.id"
 
     input:
-    path(compressed_file)
+    tuple val(meta), path(compressed_file)
 
     output:
-    path("out/*"), emit: uncompressed
+    tuple val(meta), path("out/*"), emit: uncompressed
 
     script:
     """
     mkdir out
-    cp ${compressed_file} out
+    cp ${compressed_file} "out/${meta.id}.fasta.gz"
     cd out
     gunzip *
     """
@@ -63,11 +64,11 @@ process CHANGE_DOT_TO_UNDERSCORE_CONTIGS {
     tuple val(meta), path(contigs)
 
     output:
-    tuple val(meta), path("${contigs}"), emit: underscore_contigs
+    tuple val(meta), path("${meta.id}_underscore.fasta.gz"), emit: underscore_contigs
 
     script:
     """
-    sed -i 's/\\./\\_/' ${contigs}
+    zcat ${contigs} | sed 's/\\./\\_/' | gzip > ${meta.id}_underscore.fasta.gz
     """
 }
 

--- a/modules/nf-core/maxbin2/main.nf
+++ b/modules/nf-core/maxbin2/main.nf
@@ -4,7 +4,7 @@ process MAXBIN2 {
 
     conda "bioconda::maxbin2=2.2.7"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/maxbin2:2.2.7--he1b5a44_2' :
+        'quay.io/biocontainers/maxbin2:2.2.7--hdbdd923_5' :
         'biocontainers/maxbin2:2.2.7--he1b5a44_2' }"
 
     input:

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -26,7 +26,7 @@
           "type": "string",
           "description": "Biome in format: environment_biome,environment_feature,environment_material",
           "fa_icon": "fas fa-ad",
-          "pattern": "^[a-z\\s]+,[a-z\\s]+,[a-z\\s]+$"
+          "pattern": "^[a-z\\s]+,[a-z\\s]+,[a-z\\s-]+$"
         },
         "samplesheet": {
           "type": "string",

--- a/subworkflows/local/alignment.nf
+++ b/subworkflows/local/alignment.nf
@@ -3,7 +3,7 @@
      Run subworkflow
     ~~~~~~~~~~~~~~~~~~
 */
-include { INDEX_FASTA } from '../../modules/local/align_bwa/main'
+include { INDEX_FASTA }     from '../../modules/local/align_bwa/main'
 include { ALIGNMENT_BAM   } from '../../modules/local/align_bwa/main'
 
 workflow ALIGN {


### PR DESCRIPTION
- Modify `sed . to _` to support compressed assembly files (tried to use `seqkit replace` but it replaces all . to _ but I need only all before first space)
- Added uncompressing step after alignment because binners require uncompressed fasta files :(