### PR TITLE
make PROCESS_INPUT optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ nextflow run ebi-metagenomics/genomes-generation \
 --biomes "biome,feature,material" \
 --outdir <FULL_PATH_TO_OUTDIR>
 ```
+
+### Optional arguments
+
+- `--skip_preprocessing_input (default=false)`: skip input data pre-processing step that renames ERZ-fasta files to ERR-run accessions. Useful if you process data not from ENA
+- `--skip_prok (default=false)`: do not generate prokaryotic MAGs
+- `--skip_euk (default=false)`: do not generate eukaryotic MAGs
+- `--skip_concoct (default=false)`: skip CONCOCT binner in binning process
+- `--skip_maxbin2 (default=false)`: skip MaxBin2 binner in binning process
+- `--skip_metabat2 (default=false)`: skip METABAT2 binner in binning process
+- `--merge_pairs (default=false)`: merge paired-end reads on QC step with fastp 
+
 ## Pipeline input data
 
 ### Sample sheet example

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,6 +20,7 @@ params {
     assembly_software_file     = ""
     
     // Feature flags
+    skip_preprocessing_input   = false
     merge_pairs                = false
     skip_prok                  = false
     skip_euk                   = false

--- a/workflows/genomes_generation.nf
+++ b/workflows/genomes_generation.nf
@@ -115,7 +115,6 @@ workflow GGP {
     FASTQC_BEFORE (assembly_and_runs.map{ meta, _ , reads -> [meta, reads] })
     ch_versions = ch_versions.mix(FASTQC_BEFORE.out.versions)
 
-    def input_assemblies_and_runs
     if ( params.skip_preprocessing_input ) {
         println('skipping pre-processing')
         input_assemblies_and_reads = assembly_and_runs


### PR DESCRIPTION
PROCESS_INPUT step renames files and changes ERZ to ERR in fasta files. If we have input not from ENA - that step should be skipped.