### PR TITLE
Bugfix/file download

### DIFF
--- a/download_data/scripts/generate_samplesheet.py
+++ b/download_data/scripts/generate_samplesheet.py
@@ -53,7 +53,7 @@ def get_err_erz(erz_list, outfile_software):
     with open(outfile_software, 'w') as file_software:
         for erz_acc in erz_list:
             handler_request = handler.get_assembly(erz_acc)
-            run_acc = handler_request["submitted_ftp"].strip().split('/')[-1].split('.')[0]
+            run_acc = handler_request["submitted_ftp"].strip().split('/')[-1].split('.')[0].split('_')[0]
             assembly_software = handler_request["assembly_software"]
             print(assembly_software)
             if not assembly_software:

--- a/download_data/scripts/rename-erz.py
+++ b/download_data/scripts/rename-erz.py
@@ -16,7 +16,7 @@ def main(input_dir, outfile):
     with open(outfile, 'w') as file_out:
         for erz_acc in erz_list:
             ftp_loc = handler.get_assembly(erz_acc)["submitted_ftp"]
-            run_acc = ftp_loc.strip().split('/')[-1].split('.')[0]
+            run_acc = ftp_loc.strip().split('/')[-1].split('.')[0].split("_")[0]
             if not run_acc.startswith(('ERR', 'DRR', 'SRR')):
                 print('Invalid run name {} for assembly {}'.format(run_acc, erz_acc))
                 sys.exit(1)


### PR DESCRIPTION
There has been a change in naming of assemblies generated by MGnify where they are no longer named as {accession}.fa.gz but instead have names like {accession}_cleaned.fa.gz, which breaks the renaming/download process. This fix removes additional information from the file name and retains only the accession. 